### PR TITLE
Impl option trafilatura toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ docker compose build
 ### 設定ファイル
 
 実行時引数が多くなってきたためyaml形式の設定ファイルを読み込むようにした
+リポジトリに予め含まれているconfig.yamlを参考にしてほしい
 デフォルトだとこんな感じ↓
 
 ```yaml
@@ -48,17 +49,21 @@ num_zstd_chunk_size: 1000
 temp_file_path: ./temp_refined_warc_samples.jsonl
 warc_paths_url: https://data.commoncrawl.org/crawl-data/CC-MAIN-2024-18/warc.paths.gz
 fast_text_language_recognition: False
+enable_text_extraction_from_html: False
+trafilatura_timeout: 30
 ```
 
-| 引数名                            | 説明                                    |
-|--------------------------------|---------------------------------------|
-| working_dir                    | 進捗状況を保存するファイルが置かれるフォルダ                |
-| dataset_dir                    | 抽出された圧縮済みデータの保存先フォルダ                  |
-| num_proc                       | 並列実行するプロセス数。                          |
-| num_zstd_chunk_size            | この数のwarcファイルを処理した後にzstd圧縮したデータが保存される。 |
-| temp_file_path                 | 一時ファイルの保存先（ファイル名）                     |
-| warc_paths_url                 | warc.paths.gzのダウンロード先URL              |
-| fast_text_language_recognition | FastTextによる言語判定を利用するかどうか。             |
+| 引数名                             | 説明                                             |
+|---------------------------------|------------------------------------------------|
+| working_dir                     | 進捗状況を保存するファイルが置かれるフォルダ                         |
+| dataset_dir                     | 抽出された圧縮済みデータの保存先フォルダ                           |
+| num_proc                        | 並列実行するプロセス数。                                   |
+| num_zstd_chunk_size             | この数のwarcファイルを処理した後にzstd圧縮したデータが保存される。          |
+| temp_file_path                  | 一時ファイルの保存先（ファイル名）                              |
+| warc_paths_url                  | warc.paths.gzのダウンロード先URL                       |
+| fast_text_language_recognition  | FastTextによる言語判定を利用するかどうか。                      |
+| enable_text_extraction_from_html | TrafilaturaによるHTMLからのテキスト抽出を行うかどうか。            |
+| trafilatura_timeout             | Trafilaturaのテキスト抽出にこの秒数以上必要とする場合、このhtmlをスキップする |
 
 ### 実行方法
 

--- a/config.yaml
+++ b/config.yaml
@@ -5,4 +5,5 @@ num_zstd_chunk_size: 1000
 temp_file_path: ./temp_refined_warc_samples.jsonl
 warc_paths_url: https://data.commoncrawl.org/crawl-data/CC-MAIN-2024-18/warc.paths.gz
 fast_text_language_recognition: False
+enable_text_extraction_from_html: False
 trafilatura_timeout: 30

--- a/openwarc_parallel.py
+++ b/openwarc_parallel.py
@@ -317,6 +317,8 @@ if __name__ == '__main__':
     print(f"Number of processes: {num_proc}")
     print(f"Number of ZSTD chunk size: {zstd_chunk_size}")
     print(f"Use fast text for language recognition: {use_fast_text}")
+    print(f"Trafilatura text extracting: {enable_text_extraction_from_html}")
+    print(f"\tTimeout after: {trafilatura_timeout} secs")
 
     # trafilaturaによるwarningを抑制
     logging.getLogger("trafilatura.utils").setLevel(logging.ERROR)

--- a/openwarc_parallel.py
+++ b/openwarc_parallel.py
@@ -314,6 +314,7 @@ if __name__ == '__main__':
     # 実行時引数の値をprintで出力
     print(f"Working directory: {working_dir}")
     print(f"Dataset directory: {output_folder_path}")
+    print("Note: If you are using Docker, these paths are within the container where this program is running :)")
     print(f"Number of processes: {num_proc}")
     print(f"Number of ZSTD chunk size: {zstd_chunk_size}")
     print(f"Use fast text for language recognition: {use_fast_text}")

--- a/openwarc_parallel.py
+++ b/openwarc_parallel.py
@@ -191,7 +191,7 @@ def process_warc(warc_path, use_fast_text=True, trafilatura_timeout=30, current_
 
                     result["languages-fasttext"] = lang_fast_text[0] if lang_fast_text else None
                 else:
-                    result = {"raw_data": base64.b64encode(tmp_content).decode('ascii'), "encoding": "base64"}
+                    result = {"raw_data": base64.b64encode(tmp_content).decode('utf-8'), "encoding": "base64"}
 
                 result["rec_headers"] = dict(record.rec_headers.headers)
                 result["metadata"] = metadata

--- a/openwarc_parallel.py
+++ b/openwarc_parallel.py
@@ -1,4 +1,5 @@
 import argparse
+import base64
 import concurrent
 import gzip
 import json
@@ -90,7 +91,7 @@ def download_warc_file(warc_url, max_retries=5, retry_delay=5):
     return None
 
 
-def process_warc(warc_path, use_fast_text=True, trafilatura_timeout=30, current_trial=0, max_trial=5):
+def process_warc(warc_path, use_fast_text=True, trafilatura_timeout=30, current_trial=0, max_trial=5, enable_text_extraction_from_html=True):
     """
     warcファイルを読み込んで、日本語ページかどうかの簡単なフィルタリングを行う。
     処理手順:
@@ -145,6 +146,9 @@ def process_warc(warc_path, use_fast_text=True, trafilatura_timeout=30, current_
                 tmp_content = record.content_stream().read()
 
             elif record.rec_type == 'metadata':
+                if tmp_content is None:
+                    continue
+
                 # メタデータのパース
                 metadata = parse_metadata(record.content_stream().read())
 
@@ -166,30 +170,34 @@ def process_warc(warc_path, use_fast_text=True, trafilatura_timeout=30, current_
                     if lang_fast_text is None or lang_fast_text[0][0] != "ja":
                         continue
 
-                try:
-                    # 本文の抽出にはtrafilaturaを用いる。（抽出精度が高いため）
-                    # include_formatting=Trueにすることで、抽出したテキストがMarkdown形式になる（h2タグが見出しになったり、テーブルがパースされたり）
-                    # deduplicateの効果は不明
-                    with timeout(trafilatura_timeout, timer="thread"):
-                        json_data = extract_data(tmp_content)
-                    result = json.loads(json_data)
-                except:
-                    continue
+                if enable_text_extraction_from_html:
+                    try:
+                        # 本文の抽出にはtrafilaturaを用いる。（抽出精度が高いため）
+                        # include_formatting=Trueにすることで、抽出したテキストがMarkdown形式になる（h2タグが見出しになったり、テーブルがパースされたり）
+                        # deduplicateの効果は不明
+                        with timeout(trafilatura_timeout, timer="thread"):
+                            json_data = extract_data(tmp_content)
+                        result = json.loads(json_data)
+                    except:
+                        continue
 
-                # （Swallowより）本文の文字数が400以下の場合は低品質とみなす（ただしスキップはしない）
-                if len(result["text"]) < 400:
-                    result["rejected"] = True
-                    result["rejected_reason"] = "Too_Short"
+                    # （Swallowより）本文の文字数が400以下の場合は低品質とみなす（ただしスキップはしない）
+                    if len(result["text"]) < 400:
+                        result["rejected"] = True
+                        result["rejected_reason"] = "Too_Short"
+                    else:
+                        result["rejected"] = False
+                        result["rejected_reason"] = ""
+
+                    result["languages-fasttext"] = lang_fast_text[0] if lang_fast_text else None
                 else:
-                    result["rejected"] = False
-                    result["rejected_reason"] = ""
+                    result = {"raw_data": base64.b64encode(tmp_content).decode('ascii'), "encoding": "base64"}
 
-                result["languages-fasttext"] = lang_fast_text[0] if lang_fast_text else None
                 result["rec_headers"] = dict(record.rec_headers.headers)
-
                 result["metadata"] = metadata
 
                 result_list.append(result)
+                tmp_content = None
 
         return True, warc_path, result_list
     except Exception as e:
@@ -199,7 +207,14 @@ def process_warc(warc_path, use_fast_text=True, trafilatura_timeout=30, current_
         print(f"{warc_path} restart the process.")
         del lang_predictor
 
-        return process_warc(warc_path, use_fast_text, trafilatura_timeout, current_trial+1)
+        return process_warc(
+            warc_path=warc_path,
+            use_fast_text=use_fast_text,
+            trafilatura_timeout=trafilatura_timeout,
+            current_trial=current_trial+1,
+            max_trial=max_trial,
+            enable_text_extraction_from_html=enable_text_extraction_from_html
+        )
 
 
 def signal_handler(sig, frame):
@@ -294,6 +309,7 @@ if __name__ == '__main__':
     warc_paths_url = config.get('warc_paths_url')
     use_fast_text = config.get('fast_text_language_recognition')
     trafilatura_timeout = config.get('trafilatura_timeout')
+    enable_text_extraction_from_html = config.get('enable_text_extraction_from_html')
 
     # 実行時引数の値をprintで出力
     print(f"Working directory: {working_dir}")
@@ -376,7 +392,7 @@ if __name__ == '__main__':
                             processed_file_names.append(result[1])
 
                     for warc_path in cleaned_warcs:
-                        future = executor.submit(process_warc, warc_path, use_fast_text, trafilatura_timeout, 0, 5)
+                        future = executor.submit(process_warc, warc_path, use_fast_text, trafilatura_timeout, 0, 5, enable_text_extraction_from_html)
                         future.add_done_callback(on_process_finished)
                 except:
                     traceback.print_exc()


### PR DESCRIPTION
config.yamlで`enable_text_extraction_from_html`フラグをFalseにするとtrafilaturaによるテキスト抽出処理をスキップするようになる
回線速度は速いがそれに見合うCPU/RAMスペックが無い場合に有効
